### PR TITLE
Support mesos-1.4.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ IF(CMAKE_COMPILER_IS_GNUCXX)
 ENDIF(CMAKE_COMPILER_IS_GNUCXX)
 
 project(mesos-external-container-logger
-    VERSION 0.1.3
+    VERSION 0.1.4
     LANGUAGES CXX C)
 enable_testing()
 
@@ -34,7 +34,7 @@ endif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations")
 
 # Add gtest.
-add_subdirectory (${MESOS_SRC_DIR}/build/3rdparty/gmock-1.7.0)
+add_subdirectory (${MESOS_SRC_DIR}/build/3rdparty/googletest-release-1.8.0)
 #include_directories(${gmock_SOURCE_DIR} include)
 #include_directories(${gtest_SOURCE_DIR} include)
 
@@ -44,8 +44,8 @@ link_directories(
 
 include_directories(
     ./
-    ${MESOS_SRC_DIR}/build/3rdparty/gmock-1.7.0/gtest/include
-    ${MESOS_SRC_DIR}/build/3rdparty/gmock-1.7.0/include
+    ${MESOS_SRC_DIR}/build/3rdparty/googletest-release-1.8.0/googletest/include
+    ${MESOS_SRC_DIR}/build/3rdparty/googletest-release-1.8.0/googlemock/include
     ${MESOS_SRC_DIR}/build/3rdparty/include/zookeeper
     ${MESOS_SRC_DIR}/build/3rdparty/include
     ${MESOS_SRC_DIR}/build/src

--- a/build-mesos.sh
+++ b/build-mesos.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-MESOS_VERSION=1.3.0
+MESOS_VERSION=1.4.0
 
 if [ ! -f mesos-$MESOS_VERSION.tar.gz ]; then
     curl --remote-name http://www-eu.apache.org/dist/mesos/$MESOS_VERSION/mesos-$MESOS_VERSION.tar.gz

--- a/compile.sh
+++ b/compile.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-cmake -DWITH_MESOS=$PWD/mesos-install -DMESOS_SRC_DIR=$PWD/mesos-1.3.0
+cmake -DWITH_MESOS=$PWD/mesos-install -DMESOS_SRC_DIR=$PWD/mesos-1.4.0
 make -j 6 V=0


### PR DESCRIPTION
Mesos updated the google test framework which broke some of the directory structure:
https://issues.apache.org/jira/browse/MESOS-7364

This PR addresses those changes.