### PR TITLE
Port module to Mesos 1.7+

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a container logger module for [Mesos](http://mesos.apache.org/)
 that redirects container logs to an external process.
 
-It is a port to Mesos 1.4.0 of the `ExternalContainerLogger` module
+It is a port to Mesos 1.7+ of the `ExternalContainerLogger` module
 developed in
 [MESOS-6003](https://issues.apache.org/jira/browse/MESOS-6003).
 Read the [documentation](https://reviews.apache.org/r/51258/) or this

--- a/build-mesos.sh
+++ b/build-mesos.sh
@@ -2,10 +2,10 @@
 
 set -e
 
-MESOS_VERSION=1.4.0
+MESOS_VERSION=1.7.2
 
 if [ ! -f mesos-$MESOS_VERSION.tar.gz ]; then
-    curl --remote-name http://www-eu.apache.org/dist/mesos/$MESOS_VERSION/mesos-$MESOS_VERSION.tar.gz
+    curl --remote-name http://archive.apache.org/dist/mesos/$MESOS_VERSION/mesos-$MESOS_VERSION.tar.gz
 fi
 
 if [ ! -d mesos-$MESOS_VERSION ]; then

--- a/compile.sh
+++ b/compile.sh
@@ -2,5 +2,5 @@
 
 set -e
 
-cmake -DWITH_MESOS=$PWD/mesos-install -DMESOS_SRC_DIR=$PWD/mesos-1.4.0
+cmake -DWITH_MESOS=$PWD/mesos-install -DMESOS_SRC_DIR=$PWD/mesos-1.7.2
 make -j 6 V=0

--- a/src/lib_externallogger.hpp
+++ b/src/lib_externallogger.hpp
@@ -112,9 +112,8 @@ public:
   // to the external command.
   virtual process::Future<mesos::slave::ContainerIO>
   prepare(
-      const ExecutorInfo& executorInfo,
-      const std::string& sandboxDirectory,
-      const Option<std::string>& user);
+      const ContainerID& containerId,
+      const mesos::slave::ContainerConfig& containerConfig);
 
 protected:
   Flags flags;


### PR DESCRIPTION
Commit apache/mesos@d30dc724b512264b1a65f0b5b337fbe24bc4894d changed the
container logger module interface, thus breaking the external container
logger module.

This commit enables the external container logger module to work with the
new interface (Mesos 1.7+).