### PR TITLE
Stop versioning .so file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,10 +75,10 @@ set(EXTERNAL_CONTAINER_LOGGER_SOURCES
 )
 
 # Module.
-add_library(external_container_logger-${PROJECT_VERSION}
+add_library(external_container_logger
     SHARED
     ${EXTERNAL_CONTAINER_LOGGER_SOURCES})
-target_link_libraries(external_container_logger-${PROJECT_VERSION})
+target_link_libraries(external_container_logger)
 
 set(WITH_SOURCE_MESOS "" CACHE STRING "Mesos source directory")
 set(MESOS_SOURCE_DIR ${WITH_SOURCE_MESOS})


### PR DESCRIPTION
We don't really need it since only mesos will use the module and mesos
is not built against a specific version of this module so interface is
not really a problem

Change-Id: I1bb40b3a657ea87332505467c2790919203873aa